### PR TITLE
Simplify test.linear.assumptions()

### DIFF
--- a/R/test.linear.assumptions.R
+++ b/R/test.linear.assumptions.R
@@ -57,17 +57,18 @@ test.linear.assumptions <- function(fit, mod = 1, label_plot = FALSE, ...) {
   }
   
   if (dist == "gompertz") {
-    
-    estimate.h <- function(s, t) {
-      denom <- t - c(t[-1], max(t) + 1)
-      numerator <- log(s) - log(c(s[-1], 0))
-      return(-numerator/denom)
-    }
+    # placeholder
+    warning("Gompertz models are not yet implemented in test.linear.assumptions()")
+    x <- 0
+    y <- 0
+    # estimate.h <- function(s, t) {
+    #   denom <- t - c(t[-1], max(t) + 1)
+    #   numerator <- log(s) - log(c(s[-1], 0))
+    #   return(-numerator/denom)
+    # }
     
     xlab <- "log(time)"
     ylab <- "h(t)"
-    xlim = range(pretty(all_times))
-    # ylim = range(pretty(estimate.h(survs[[1]], times[[1]])))
     legend_text <- "Gompertz distributional assumption"
     ### NEED TO CHECK --- WHAT IS V2???
     # pts <- lapply(1:dim(split_mat)[1],
@@ -75,10 +76,6 @@ test.linear.assumptions <- function(fit, mod = 1, label_plot = FALSE, ...) {
     #                 cbind(times[[m]],
     #                       estimate.h(survs[[m]],
     #                                  times[[m]])))[V2 != 0, ]
-    y0 <- lapply(mapply(cbind, survs, times), function(x) estimate.h(x[, 1], x[, 2]))
-    not_zero <- lapply(y, function(x) x != 0)
-    x <- mapply(subset, times, not_zero)
-    y <- mapply(subset, y0, not_zero)
   }
   
   # actual plot

--- a/R/test.linear.assumptions.R
+++ b/R/test.linear.assumptions.R
@@ -11,13 +11,13 @@ test.linear.assumptions <- function(fit, mod = 1, label = FALSE, ...) {
   stopifnot(dist %in% c("exp", "exponential", "weibull", "weibull.quiet", "weibullaf", "weibullph",
                         "llogis", "loglogistic", "lognormal", "lnorm", "gompertz"))
   
-  split_vector <- 1
-  for (i in 2:length(fit$misc$km$time)) {
-    if (fit$misc$km$time[i] < fit$misc$km$time[i - 1]) {
-      split_vector <- c(split_vector, i - 1, i)
-    }
-  }
-  split_vector <- c(split_vector, length(fit$misc$km$time))
+  
+  split_vector <- which(diff(fit$misc$km$time) < 0)
+  split_vector <- sort(c(1,
+                         split_vector,
+                         split_vector + 1,
+                         length(fit$misc$km$time)))
+
   split_mat <- matrix(split_vector,
                       length(split_vector)/2,
                       2,

--- a/man/test.linear.assumptions.Rd
+++ b/man/test.linear.assumptions.Rd
@@ -8,7 +8,7 @@ Tests the linear assumptions for the parametric model
 Tests the linear assumptions for the parametric model
 }
 \usage{
-test.linear.assumptions(fit, mod = 1, label = FALSE, ...)
+test.linear.assumptions(fit, mod = 1, label_plot = FALSE, ...)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -18,7 +18,7 @@ an object of class survHE
   \item{mod}{
 index or name of a model in fit. Defaults to 1.
 }
-  \item{label}{
+  \item{label_plot}{
 if TRUE, labels assumptions. Defaults to FALSE.
 }
   \item{\dots}{


### PR DESCRIPTION
This is a proposal to further simplify test.linear.assumptions(). It is an attempt to streamline the code in order to make it easier to understand and maintain. In addition the code for Gompertz models has been replaced by a placeholder: this is a stopgap measure for issue #9 and also fixes one of the warnings during build.

Toy example:
```r
mle <- fit.models(formula=Surv(recyrs,censrec) ~ group,
  data=bc,
  distr=c("exp", "weibull", "llogis", "lognormal", "gompertz"),
  method="mle")
par(mfrow = c(2, 3))
for (i in 1:5) test.linear.assumptions(mle, mod = i, label_plot = TRUE)
par(mfrow = c(1, 1))
```