### PR TITLE
Fix warnings

### DIFF
--- a/man/internal_stan.Rd
+++ b/man/internal_stan.Rd
@@ -1,0 +1,34 @@
+\name{internal_stan}
+\alias{internal_stan}
+\alias{stanmodels}
+\alias{stan_files}
+\alias{model_Exponential}
+\alias{model_Gamma}
+\alias{model_GenF}
+\alias{model_GenGamma}
+\alias{model_Gompertz}
+\alias{model_logLogistic}
+\alias{model_logNormal}
+\alias{model_PolyWeibull}
+\alias{model_RP}
+\alias{model_WeibullAF}
+\alias{model_WeibullPH}
+\alias{Rcpp_model_Exponential-class}
+\alias{Rcpp_model_Gamma-class}
+\alias{Rcpp_model_GenF-class}
+\alias{Rcpp_model_GenGamma-class}
+\alias{Rcpp_model_Gompertz-class}
+\alias{Rcpp_model_logLogistic-class}
+\alias{Rcpp_model_logNormal-class}
+\alias{Rcpp_model_PolyWeibull-class}
+\alias{Rcpp_model_RP-class}
+\alias{Rcpp_model_WeibullAF-class}
+\alias{Rcpp_model_WeibullPH-class}
+\docType{data}
+\title{
+Internal objects used by stan
+}
+\description{
+Objects, C++ and S4 classes used by stan to fit parametric survival models.
+}
+\keyword{internal}

--- a/man/test.linear.assumptions.Rd
+++ b/man/test.linear.assumptions.Rd
@@ -1,6 +1,6 @@
 \name{test.linear.assumptions}
 \alias{test.linear.assumptions}
-%- Also NEED an '\alias' for EACH other topic documented here.
+
 \title{
 Tests the linear assumptions for the parametric model
 }
@@ -10,7 +10,7 @@ Tests the linear assumptions for the parametric model
 \usage{
 test.linear.assumptions(fit, mod = 1, label = FALSE, ...)
 }
-%- maybe also 'usage' for other objects documented here.
+
 \arguments{
   \item{fit}{
 an object of class survHE
@@ -25,20 +25,11 @@ if TRUE, labels assumptions. Defaults to FALSE.
 further arguments, passed on to points()
 }
 }
-\details{
-%%  ~~ If necessary, more details than the description above ~~
-}
 \value{
 A diagnostic plot
-}
-\references{
-%% ~put references to the literature/web site here ~
 }
 \author{
 William Browne
 }
-\seealso{
-%% ~~objects to See Also as \code{\link{help}}, ~~~
-}
-\examples{}
-\keyword{}
+\keyword{survival}
+\keyword{hplot}


### PR DESCRIPTION
This PR, together with #10, will fix all warnings in R cmd check. That's a prerequisite for cran submission ;-) It's based on master - if you want to accept both this one and #10, merge this one first.

- remove empty sections in test.linear.assumptions.Rd - fixes a note.
- document hidden stan objects in an internal Rd file  - fixes a warning.

Happy New Year!
Peter 