### PR TITLE
Fixed print.survHE issue for GenGamma ~ 1

### DIFF
--- a/R/print.survHE.R
+++ b/R/print.survHE.R
@@ -325,7 +325,7 @@ print.survHE <- function(x,mod=1,...) {
       }
       
       if (x$models[[mod]]@model_name=="GenGamma") {
-        mu <- matrix(table[grep("beta",rownames(table)),][1,],ncol=4,nrow=1)
+        mu <- matrix(table[grep("beta",rownames(table)),,drop=FALSE][1,],ncol=4,nrow=1)
         rownames(mu) <- "mu"
         sigma <- matrix(table[grep("sigma",rownames(table)),],ncol=4)
         rownames(sigma) <- "sigma"


### PR DESCRIPTION
Fixed print.survHE issue for Generalized Gamma model fitted with no covariates, i.e. Surv(...) ~ 1.
When the table object was subset with only one beta, the second dimension of the matrix was dropped but still subset on subsequently. Added a drop=FALSE in the subset by grep("beta") to avoid it.