### PR TITLE
Compatibility with next rstan

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,10 +38,11 @@ LinkingTo:
     Rcpp (>= 0.12.19),
     RcppEigen (>= 0.3.3.4.0),
     rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    StanHeaders (>= 2.18.0),
+    RcppParallel (>= 5.0.2)
 Additional_repositories: https://inla.r-inla-download.org/R/stable
 Encoding: UTF-8
 LazyData: true
 NeedsCompilation: yes
 SystemRequirements: GNU make
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,10 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error
+
+STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS)
+PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
+PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
+
 CXX_STD = CXX14
 SOURCES = $(wildcard stan_files/*.stan)
 OBJECTS = $(SOURCES:.stan=.o) init.o

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,9 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG
+
+STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS)
+PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
+PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 
 CXX_STD = CXX14
 SOURCES = $(wildcard stan_files/*.stan)

--- a/src/stan_files/Exponential.stan
+++ b/src/stan_files/Exponential.stan
@@ -3,16 +3,16 @@
 functions {
   // Defines the log hazard
   vector log_h (vector t, vector rate) {
-    vector[num_elements(t)] log_h;
-    log_h = log(rate);
-    return log_h;
+    vector[num_elements(t)] log_hvec;
+    log_hvec = log(rate);
+    return log_hvec;
   }
   
   // Defines the log survival
   vector log_S (vector t, vector rate) {
-    vector[num_elements(t)] log_S;
-    log_S = -rate .* t;
-    return log_S;
+    vector[num_elements(t)] log_Svec;
+    log_Svec = -rate .* t;
+    return log_Svec;
   }
   
   // Defines the sampling distribution

--- a/src/stan_files/Gompertz.stan
+++ b/src/stan_files/Gompertz.stan
@@ -3,18 +3,18 @@
 functions {
   // Defines the log hazard
   vector log_h (vector t, real shape, vector rate) {
-    vector[num_elements(t)] log_h;
-    log_h = log(rate) + (shape * t);
-    return log_h;
+    vector[num_elements(t)] log_hvec;
+    log_hvec = log(rate) + (shape * t);
+    return log_hvec;
   }
   
   // Defines the log survival
   vector log_S (vector t, real shape, vector rate) {
-    vector[num_elements(t)] log_S;
+    vector[num_elements(t)] log_Svec;
     for (i in 1:num_elements(t)) {
-      log_S[i] = -rate[i]/shape * (exp(shape * t[i]) - 1);
+      log_Svec[i] = -rate[i]/shape * (exp(shape * t[i]) - 1);
     }
-    return log_S;
+    return log_Svec;
   }
   
   // Defines the sampling distribution

--- a/src/stan_files/WeibullAF.stan
+++ b/src/stan_files/WeibullAF.stan
@@ -3,18 +3,18 @@
 functions {
   // Defines the log hazard
   vector log_h (vector t, real shape, vector scale) {
-    vector[num_elements(t)] log_h;
-    log_h = log(shape)+(shape-1)*log(t ./ scale)-log(scale);
-    return log_h;
+    vector[num_elements(t)] log_hvec;
+    log_hvec = log(shape)+(shape-1)*log(t ./ scale)-log(scale);
+    return log_hvec;
   }
   
   // Defines the log survival
   vector log_S (vector t, real shape, vector scale) {
-    vector[num_elements(t)] log_S;
+    vector[num_elements(t)] log_Svec;
     for (i in 1:num_elements(t)) {
-      log_S[i] = -pow((t[i]/scale[i]),shape);
+      log_Svec[i] = -pow((t[i]/scale[i]),shape);
     }
-    return log_S;
+    return log_Svec;
   }
   
   // Defines the sampling distribution

--- a/src/stan_files/WeibullPH.stan
+++ b/src/stan_files/WeibullPH.stan
@@ -3,18 +3,18 @@
 functions {
   // Defines the log hazard
   vector log_h (vector t, real shape, vector scale) {
-    vector[num_elements(t)] log_h;
-    log_h = log(shape)+(shape-1)*log(t ./ scale)-log(scale);
-    return log_h;
+    vector[num_elements(t)] log_hvec;
+    log_hvec = log(shape)+(shape-1)*log(t ./ scale)-log(scale);
+    return log_hvec;
   }
   
   // Defines the log survival
   vector log_S (vector t, real shape, vector scale) {
-    vector[num_elements(t)] log_S;
+    vector[num_elements(t)] log_Svec;
     for (i in 1:num_elements(t)) {
-      log_S[i] = -pow((t[i]/scale[i]),shape);
+      log_Svec[i] = -pow((t[i]/scale[i]),shape);
     }
-    return log_S;
+    return log_Svec;
   }
   
   // Defines the sampling distribution

--- a/src/stan_files/logLogistic.stan
+++ b/src/stan_files/logLogistic.stan
@@ -3,20 +3,20 @@
 functions {
   // Defines the log hazard
   vector log_h (vector t, real shape, vector scale) {
-    vector[num_elements(t)] log_h;
+    vector[num_elements(t)] log_hvec;
     for (i in 1:num_elements(t)) {
-      log_h[i] = log(shape)-log(scale[i])+(shape-1)*(log(t[i])-log(scale[i]))-log(1+pow((t[i]/scale[i]),shape));
+      log_hvec[i] = log(shape)-log(scale[i])+(shape-1)*(log(t[i])-log(scale[i]))-log(1+pow((t[i]/scale[i]),shape));
     }
-    return log_h;
+    return log_hvec;
   }
   
   // Defines the log survival
   vector log_S (vector t, real shape, vector scale) {
-    vector[num_elements(t)] log_S;
+    vector[num_elements(t)] log_Svec;
     for (i in 1:num_elements(t)) {
-      log_S[i] = -log(1+pow((t[i]/scale[i]),shape));
+      log_Svec[i] = -log(1+pow((t[i]/scale[i]),shape));
     }
-    return log_S;
+    return log_Svec;
   }
   
   // Defines the sampling distribution

--- a/src/stan_files/logNormal.stan
+++ b/src/stan_files/logNormal.stan
@@ -3,22 +3,22 @@
 functions {
   // Defines the log survival
   vector log_S (vector t, vector mean, real sd) {
-    vector[num_elements(t)] log_S;
+    vector[num_elements(t)] log_Svec;
     for (i in 1:num_elements(t)) {
-      log_S[i] = log(1-Phi((log(t[i])-mean[i])/sd));
+      log_Svec[i] = log(1-Phi((log(t[i])-mean[i])/sd));
     }
-    return log_S;
+    return log_Svec;
   }
   
   // Defines the log hazard
   vector log_h (vector t, vector mean, real sd) {
-    vector[num_elements(t)] log_h;
+    vector[num_elements(t)] log_hvec;
     vector[num_elements(t)] ls;
     ls = log_S(t,mean,sd);
     for (i in 1:num_elements(t)) {
-      log_h[i] = lognormal_lpdf(t[i]|mean[i],sd) - ls[i];
+      log_hvec[i] = lognormal_lpdf(t[i]|mean[i],sd) - ls[i];
     }
-    return log_h;
+    return log_hvec;
   }
 
   // Defines the sampling distribution


### PR DESCRIPTION
Hi,

This PR adds the changes to build flags that are needed for compatibility with the upcoming release of rstan. These changes include adding compiler & linker flags needed for working with `StanHeaders` >= 2.26, namely the addition of the TBB (`RcppParallel`).

Additionally, this PR adds a compiler flag to your `Makevars` files which is needed for compatibility with the upcoming version of `rstan`:  `-DUSE_STANC3`

The Stan-to-c++ transpiler (`stanc`) was refactored after 2.21, and so different c++ is used in the new `rstan` package (>= 2.26). Because of this, the flag `-DUSE_STANC3` needs to be added when a stan model is being run using the new rstan package (and the new stanc implementation).

I also had to make some minor changes to your models, as the new compiler throws an error when you declare a variable with the same name as the function that you're defining.

Feel free to let me know if you need any more info.

Thanks!
Andrew