### PR TITLE
Implements the support for the INLA Gamma model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ License: GPL (>=3)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2.9000
+RoxygenNote: 7.3.3
 Biarch: true
 Depends: 
     methods,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ License: GPL (>=3)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Biarch: true
 Depends: 
     methods,
@@ -53,3 +52,4 @@ Additional_repositories:
     https://inla.r-inla-download.org/R/stable/,
     https://giabaio.r-universe.dev/
 SystemRequirements: GNU make
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,14 @@
 # 2.0.52 (development version)
 
+## April 2026
+* Adds support for the handling and plotting of Gamma models fitted in INLA (which will soon be available in `survHEinla` too).
+Specifically, adds the `gam` support in the hidden function `load_availables()`. It also adds the function `rescale_stats_inla_gam()`,
+which takes care of the rescaling for the `print` method.
+
 ## March 2026
 * Fixes a small typo in the utility function `survHE:::make_surv_curve_plot` -- replaces `size` with `linewidth` in a call to `geom_line`. This avoids a warning.
+* Adds facility to implement the newly available Gamma survival model from INLA.
+* Fix slight imprecision -- INLA can't do RPS as a built-in model, so `survHE:::load_availables()` has been modified accordingly.
 
 # 2.0.51 
 ## January 2026

--- a/R/fit_models.R
+++ b/R/fit_models.R
@@ -71,8 +71,7 @@
 #' @author Gianluca Baio
 #' @seealso \code{make.surv}
 #' @template refs
-#' @keywords Parametric survival models Bayesian inference via Hamiltonian
-#' Monte Carlo Bayesian inference via Integrated Nested Laplace Approximation
+#' @keywords Parametric survival models Bayesian inference via Hamiltonian Monte Carlo Bayesian inference via Integrated Nested Laplace Approximation
 #' @examples
 #' \dontrun{
 #' # Loads an example dataset from 'flexsurv'

--- a/R/fit_models.R
+++ b/R/fit_models.R
@@ -19,9 +19,9 @@
 #' \code{flexsurv}:
 #' "exponential","gamma","genf","gengamma","gompertz","weibull",
 #' "weibullPH","loglogistic","lognormal" \code{INLA}:
-#' "exponential","weibull","lognormal","loglogistic" \code{hmc}:
-#' "exponential","gamma","genf","gengamma","gompertz","weibull","weibullPH",
-#' "loglogistic","lognormal"
+#' "exponential","weibull","lognormal","loglogistic","gompertz","gamma" 
+#' \code{hmc}: "exponential","gamma","genf","gengamma","gompertz","weibull",
+#' "weibullPH","loglogistic","lognormal"
 #' @param method A string specifying the inferential method (\code{'mle'},
 #' \code{'inla'} or \code{'hmc'}). If \code{method} is set to \code{'hmc'},
 #' then \code{survHE} will write suitable model code in the Stan language

--- a/R/make.transition.probs.R
+++ b/R/make.transition.probs.R
@@ -177,11 +177,17 @@ make_data_multi_state=function(data,id="id",prog="prog",death="death",prog_t="pr
         to=3,                                 # arriving state 
         trans=2,                              # transition code (2 = Pre -> Death)  
         Tstart=0,                             # entry time
-        Tstop=!!sym(death_t),                 # exit time
+#        Tstop=!!sym(death_t),                 # exit time
+        Tstop=if_else(			      # exit time
+          !!sym(prog)==1,
+          !!sym(prog_t),
+          !!sym(death_t)
+        ),
         time=Tstop-Tstart,                    # time-to-event = Tstop-Tstart
         status=case_when(                     # censoring indicator:
                                               #  1 if died at progression; 0 otherwise
-          (!!sym(death)==1 & !!sym(prog_t)==!!sym(death_t))~1,     
+#          (!!sym(death)==1 & !!sym(prog_t)==!!sym(death_t))~1,
+          (!!sym(death)==1 & !!sym(prog_t)==0)~1,          
           TRUE~0
         )
       )  %>% select(id,from,to,trans,Tstart,Tstop,time,status,treat,everything()) 

--- a/R/utils_fit_models.R
+++ b/R/utils_fit_models.R
@@ -141,8 +141,7 @@ make_KM <- function(formula,data) {
 #' @author Gianluca Baio
 #' @seealso fit.models
 #' @references Baio (2020). survHE
-#' @keywords Parametric survival models Bayesian inference via Hamiltonian
-#' Monte Carlo Bayesian inference via Integrated Nested Laplace Approximation
+#' @keywords Parametric survival models Bayesian inference via Hamiltonian Monte Carlo Bayesian inference via Integrated Nested Laplace Approximation
 #' @noRd 
 format_output_fit.models <- function(output,method,distr,formula,data) {
   
@@ -199,8 +198,7 @@ format_output_fit.models <- function(output,method,distr,formula,data) {
 #' @author Gianluca Baio
 #' @seealso fit.models
 #' @references Baio (2020). survHE
-#' @keywords Parametric survival models Bayesian inference via Hamiltonian
-#' Monte Carlo Bayesian inference via Integrated Nested Laplace Approximation
+#' @keywords Parametric survival models Bayesian inference via Hamiltonian Monte Carlo Bayesian inference via Integrated Nested Laplace Approximation
 #' @noRd 
 load_availables <- function() {
   # INLA can only do a limited set of models (for now) so if user has selected
@@ -259,8 +257,7 @@ load_availables <- function() {
 #' @author Gianluca Baio
 #' @seealso fit.models
 #' @references Baio (2020). survHE
-#' @keywords Parametric survival models Bayesian inference via Hamiltonian
-#' Monte Carlo Bayesian inference via Integrated Nested Laplace Approximation
+#' @keywords Parametric survival models Bayesian inference via Hamiltonian Monte Carlo Bayesian inference via Integrated Nested Laplace Approximation
 #' @noRd 
 manipulate_distributions <- function(x){
   # selected model checks -----

--- a/R/utils_fit_models.R
+++ b/R/utils_fit_models.R
@@ -225,8 +225,9 @@ load_availables <- function() {
            "weibullPH" = "wph",
            "lognormal" = "lno",
            "loglogistic" = "llo",
-           "rps" = "rps",
-           "gompertz" = "gom"      # added Mar 19, 2021
+#           "rps" = "rps",          # INLA can't actually do RPS as a built-in model!
+           "gompertz" = "gom",      # added Mar 19, 2021
+           "gamma" = "gam"          # added Mar 16, 2026
     ),
     hmc=c("Exponential" = "exp",
           "Gamma" = "gam",

--- a/R/utils_print_survHE.R
+++ b/R/utils_print_survHE.R
@@ -552,6 +552,51 @@ rescale_stats_inla_gom <- function(x,mod,nsim=1000) {
   return(res)
 }
 
+#' Helper function to rescale the stats for the Gamma model (INLA)
+#' 
+#' @param table The table with the relevant values for the model 
+#' parameters
+#' @return \item{res}{The resulting stats}
+#' @author Gianluca Baio
+#' @seealso print.survHE
+#' @references Baio (2020). survHE
+#' @keywords INLA Gamma
+#' @noRd 
+rescale_stats_inla_gam <- function(x,mod,nsim=1000) {
+  # Hyperparameter [[1]] for gamma.surv is the shape phi (= precision parameter).
+  # It is already on the natural scale in $marginals.hyperpar.
+  phi_sim <- INLA::inla.rmarginal(nsim, x$models[[mod]]$marginals.hyperpar[[1]])
+  fixeff_sim <- lapply(1:nrow(x$models[[mod]]$summary.fixed), function(i) {
+    INLA::inla.rmarginal(nsim, x$models[[mod]]$marginals.fixed[[i]])
+  })
+  # Back-transform intercept: INLA fitted on t/time_max so
+  # eta_inla = log(E[t/time_max]) => mean_true = exp(intercept_inla + log(time_max))
+  # Same +log(time_max) correction as lno (both use log link on mean).
+  if (attributes(terms(x$misc$formula))$intercept == 1) {
+    mean_sim <- exp(fixeff_sim[[1]] + log(max(x$misc$km$time)))
+    # Rate: b = phi / mean  (from E[t] = shape/rate = phi/b)
+    rate_sim  <- phi_sim / mean_sim
+  }
+  shape <- phi_sim  %>% make_stats %>% matrix(., ncol = 4)
+  rate  <- rate_sim %>% make_stats %>% matrix(., ncol = 4)
+  rownames(shape) <- "shape"
+  rownames(rate)  <- "rate"
+  res <- rbind(shape, rate)
+  # Covariate effects: no sign flip (same convention as lno, exp, gom).
+  # The beta_k are log-time-ratios (AFT parameterisation via the log link).
+  if (length(fixeff_sim) > 1) {
+    effects <- lapply(2:nrow(x$models[[mod]]$summary.fixed), function(i) {
+      fixeff_sim[[i]]
+    })
+    effects <- matrix(unlist(lapply(effects, function(i) i %>% make_stats)),
+                      nrow = length(fixeff_sim) - 1, ncol = 4, byrow = TRUE)
+    rownames(effects) <- x$models[[mod]]$names.fixed[-1]
+    res <- rbind(res, effects)
+  }
+  colnames(res) <- c("mean", "se", "L95%", "U95%")
+  return(res)
+}
+
 #' Helper function to create summary stats
 #' 
 #' @param x A vector of simulations

--- a/man/fit.models.Rd
+++ b/man/fit.models.Rd
@@ -21,9 +21,9 @@ to be fitted.  Available options are:
 \code{flexsurv}:
 "exponential","gamma","genf","gengamma","gompertz","weibull",
 "weibullPH","loglogistic","lognormal" \code{INLA}:
-"exponential","weibull","lognormal","loglogistic" \code{hmc}:
-"exponential","gamma","genf","gengamma","gompertz","weibull","weibullPH",
-"loglogistic","lognormal"}
+"exponential","weibull","lognormal","loglogistic","gompertz","gamma"
+\code{hmc}: "exponential","gamma","genf","gengamma","gompertz","weibull",
+"weibullPH","loglogistic","lognormal"}
 
 \item{method}{A string specifying the inferential method (\code{'mle'},
 \code{'inla'} or \code{'hmc'}). If \code{method} is set to \code{'hmc'},

--- a/man/survHE-package.Rd
+++ b/man/survHE-package.Rd
@@ -20,6 +20,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Gianluca Baio \email{g.baio@ucl.ac.uk}
 
+Authors:
+\itemize{
+  \item Gianluca Baio \email{g.baio@ucl.ac.uk}
+}
+
 Other contributors:
 \itemize{
   \item Andrea Berardi \email{and.be.like@gmail.com} [contributor]


### PR DESCRIPTION
Adds support for the handling and plotting of Gamma models fitted in INLA (which will soon be available in `survHEinla` too). Specifically, adds the `gam` support in the hidden function `load_availables()`. It also adds the function `rescale_stats_inla_gam()`, which takes care of the rescaling for the `print` method.